### PR TITLE
only split result by first colon for provider

### DIFF
--- a/src/apps/onestop4all/views/Result/Result.tsx
+++ b/src/apps/onestop4all/views/Result/Result.tsx
@@ -40,8 +40,9 @@ export function Result() {
     }, [searchSrvc]);
 
     useEffect(() => {
-        setLoading(true);
-        const [provider, id] = resultId.split(":");
+
+        const [provider, ...rest] = resultId.split(":");
+        const id = rest.join(":");
         if (!provider || !id) {
             throw new Error("Was not able to find a provider or an ID!");
         }


### PR DESCRIPTION
Some of the dataset we provide contain `:` in the id  so splitting provider and id on the first one does not work. For example this [dataset](https://aquainfra.dev.52north.org/search?searchterm=glomma&pageSize=20&sort=&dataProvider=aquainfra-platform&dataProvider=arcticdatacentre&dataProvider=ceda&dataProvider=copernicusmarine&dataProvider=eea&dataProvider=emodnet&dataProvider=helcom&dataProvider=ices&dataProvider=inspire-hy&dataProvider=inspire-of&dataProvider=inspire-sr&dataProvider=jcdp&dataProvider=odims&dataProvider=syke&dataProvider=zenodo) where the call to pygeoapi fails due to missing parts of the id .i.e. [:af047ff6-e92a-47a0-a9ab-1b2d1e011092](https://vm4072.kaj.pouta.csc.fi/ddas/oapir/collections/arcticdatacentre/items/no.niva:af047ff6-e92a-47a0-a9ab-1b2d1e011092) 